### PR TITLE
Update printand add MaxHeight functions in BST

### DIFF
--- a/src/algorithm/binarySearchTree.ts
+++ b/src/algorithm/binarySearchTree.ts
@@ -9,17 +9,6 @@ class TreeNode<Key extends number | string, Val> {
 		this.key = key
 		this.val = val
 	}
-
-	public toString() {
-		this.print("", this, false)
-	}
-	private print(prefix: string, node: TreeNode<Key, Val>, isLeft: boolean) {
-		if (node != null) {
-			console.log(prefix + (isLeft ? "|-- " : "\\-- ") + node.key)
-			this.print(prefix + (isLeft ? "|   " : "    "), node.left, true)
-			this.print(prefix + (isLeft ? "|   " : "    "), node.right, false)
-		}
-	}
 }
 
 /**
@@ -51,7 +40,6 @@ export class BinarySearchTree<Key extends number | string, Val> {
 		} else {
 			node.val = val
 		}
-
 		return node
 	}
 
@@ -182,13 +170,53 @@ export class BinarySearchTree<Key extends number | string, Val> {
 
 	/**
 	 * Prints binary search tree
+	 * Inspired by https://flaviocopes.com/golang-data-structure-binary-search-tree/
 	 * @returns
 	 */
 	public print() {
-		if (this.root != null) {
-			return this.root.toString()
+		// Draw lines for debugging
+		var maxHeight = this.getMaxHeight()
+		if (maxHeight == 0) return
+		var line = "--------"
+		var current = ""
+		for (var i = 0; i < maxHeight; i++) {
+			current += line
 		}
 
-		return ""
+		console.log(current)
+		this.stringify(this.root, 0)
+		console.log(current)
+	}
+
+	private stringify(n: TreeNode<Key, Val> | null, level: number) {
+		if (!n) return
+
+		var format = ""
+		for (var i = 0; i < level; i++) {
+			format += "       "
+		}
+
+		format += "----[ "
+		level++
+
+		// change the order for logs to display smaller value to right
+		this.stringify(n.right, level)
+		console.log(format + n.key)
+		this.stringify(n.left, level)
+	}
+
+	/**
+	 * Return max height of Binary Search Tree
+	 * @returns max height
+	 */
+	public getMaxHeight(): number {
+		return this.getMaxHeightRecursively(this.root)
+	}
+
+	private getMaxHeightRecursively(node: TreeNode<Key, Val> | null): number {
+		if (!node) return 0
+		if (node.left == null && node.right == null) return 1
+
+		return 1 + Math.max(this.getMaxHeightRecursively(node.left), this.getMaxHeightRecursively(node.right))
 	}
 }

--- a/tests/algorithm/binarySearchTree.test.ts
+++ b/tests/algorithm/binarySearchTree.test.ts
@@ -50,7 +50,6 @@ test("deletion", () => {
 		var result = bst.entries()
 		expect(result.length).toBe(input.length - i - 1)
 		expect(bst.get(input[i])).toBe(null)
-
 		// check if the bst has correct nodes
 		for (var j = i + 1; j < input.length; j++) {
 			expect(bst.get(input[j])).toBe(input[j])
@@ -111,12 +110,25 @@ test("Has Key", () => {
 	}
 })
 
-test("ToString", () => {
+test("Print and Get Max Height", () => {
 	var bst = new BinarySearchTree<number, number>()
 	bst.print()
 	var input = [41, 20, 65, 11, 29, 32, 50, 91, 72, 99];
 	for (var i = 0; i < input.length; i++) {
 		bst.set(input[i], i)
+	}
+	var height = bst.getMaxHeight()
+	expect(height).toBe(4)
+
+	bst.print()
+	input.sort()
+	bst.clear()
+
+	for (var i = 0; i < input.length; i++) {
+		bst.set(input[i], i)
+		var height = bst.getMaxHeight()
+		expect(height).toBe(i + 1)
+
 	}
 	bst.print()
 })


### PR DESCRIPTION
## Description
* Today I was wondering how I can implement generic BST in golang which does not have generi typec.  And then I found this [article](https://flaviocopes.com/golang-data-structure-binary-search-tree/).
It implements `print` function I was looking for last week. 👍 
* Update the print function to display the shape of tree
* Implement `getMaxHeight` to get max height of bst

## ScreenShots
![image](https://user-images.githubusercontent.com/18569016/68990740-28c1d980-089a-11ea-93ea-a5a8dc6aace1.png)
![image](https://user-images.githubusercontent.com/18569016/68990746-3d05d680-089a-11ea-81fe-61fe5f7987ff.png)

